### PR TITLE
add exception handling if there is error in converting description rst to html

### DIFF
--- a/localshop/packages/models.py
+++ b/localshop/packages/models.py
@@ -4,11 +4,13 @@ import docutils.core
 from django.contrib.auth.models import User
 from django.db import models
 from django.core.urlresolvers import reverse
+from django.utils.html import escape
 from model_utils import Choices
 from model_utils.fields import AutoCreatedField, AutoLastModifiedField
 
 from localshop.packages.utils import OverwriteStorage
 
+from docutils.utils import SystemMessage
 
 class Classifier(models.Model):
     name = models.CharField(max_length=255, unique=True)
@@ -83,9 +85,13 @@ class Release(models.Model):
 
     @property
     def description_html(self):
-        parts = docutils.core.publish_parts(
-            self.description, writer_name='html4css1')
-        return parts['fragment']
+        try:
+            parts = docutils.core.publish_parts(
+                self.description, writer_name='html4css1')
+            return parts['fragment']
+        except SystemMessage:
+            desc = escape(self.description)
+            return '<pre>%s</pre>' % desc
 
 
 def release_file_upload_to(instance, filename):


### PR DESCRIPTION
i got the following error

`<string>:2: (SEVERE/4) Unexpected section title or transition.`

when localshop try to access property `description_html` in packages model

here the decription value when i get that error

`[u'Pygments',
 u'    ~~~~~~~~',
 u'',
 u'    Pygments is a syntax highlighting package written in Python.',
 u'',
 u'    It is a generic syntax highlighter for general use in all kinds of software',
 u'    such as forum systems, wikis or other applications that need to prettify',
 u'    source code. Highlights are:',
 u'',
 u'    * a wide range of common languages and markup formats is supported',
 u'    * special attention is paid to details, increasing quality by a fair amount',
 u'    * support for new languages and formats are added easily',
 u'    * a number of output formats, presently HTML, LaTeX, RTF, SVG, all image       formats that PIL supports and ANSI sequences',
 u'    * it is usable as a command-line tool and as a library',
 u'    * ... and it highlights even Brainfuck!',
 u'',
 u'    The`Pygments tip`_ is installable with``easy_install Pygments==dev``.',
 u'',
 u'    .. _Pygments tip:',
 u'       http://bitbucket.org/birkenfeld/pygments-main/get/tip.zip#egg=Pygments-dev',
 u'',
 u'    :copyright: Copyright 2006-2010 by the Pygments team, see AUTHORS.',
 u'    :license: BSD, see LICENSE for details.']`
