### PR TITLE
Fix kombu version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'Django>=1.4',
     'django-kombu==0.9.4',
     'eventlet>=0.9.15',
-    'kombu>=1.5.1',
+    'kombu>=1.5.1,<2.2.0',
     'logan>=0.2.1',
     'gunicorn>=0.13.4',
     'python-daemon>=1.6',


### PR DESCRIPTION
Celery requires `kombu>=2.1.8,<2.2.0` but version 2.2.1 gets installed from pypi.

Causing errors when running `localshop`

Fixes #18
