### PR TITLE
Fix urls.py slash behaviour so pip install works.

### DIFF
--- a/localshop/apps/packages/urls_simple.py
+++ b/localshop/apps/packages/urls_simple.py
@@ -4,7 +4,7 @@ from localshop.apps.packages import views
 
 
 urlpatterns = patterns('',
-    url('^$', views.SimpleIndex.as_view(), name='simple_index'),
-    url('^/(?P<slug>[^/]+)/(?P<version>.*?)$', views.SimpleDetail.as_view(),
+    url(r'^$', views.SimpleIndex.as_view(), name='simple_index'),
+    url(r'^(?P<slug>[^/]+)/(?P<version>.*?)$', views.SimpleDetail.as_view(),
         name='simple_detail')
 )

--- a/localshop/conf/server.py
+++ b/localshop/conf/server.py
@@ -55,7 +55,8 @@ USE_TZ = True
 
 SITE_ID = 1
 
-APPEND_SLASH = False
+# This is actually the default - apparently causes issues with pip search
+APPEND_SLASH = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"

--- a/localshop/urls.py
+++ b/localshop/urls.py
@@ -14,7 +14,7 @@ urlpatterns = patterns('',
     url(r'^packages',
         include('localshop.apps.packages.urls', namespace='packages')),
 
-    url(r'^simple', include('localshop.apps.packages.urls_simple',
+    url(r'^simple/', include('localshop.apps.packages.urls_simple',
         namespace='packages-simple')),
 
     url(r'^permissions',


### PR DESCRIPTION
This was just to get pip install working - basically switched back to using `APPEND_SLASH = True`, so that `http://host:port/simple` and `http://host:port/simple/` both work, as well as say `http://host:port/simple/yolk` and `http://host:portsimple/yolk/`.
