### PR TITLE
attempting to fix the seek issue using stringio

### DIFF
--- a/localshop/apps/packages/tasks.py
+++ b/localshop/apps/packages/tasks.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from cStringIO import StringIO
 
 from celery.task import task
 from django.core.files import File
@@ -17,7 +18,7 @@ def download_file(pk):
 
     # Write the file to the django file field
     filename = os.path.basename(release_file.url)
-    streaming_file = File(response.raw, filename)
+    streaming_file = File(StringIO(response.raw.read()), filename)
 
     # Setting the size manually since Django can't figure it our from
     # the raw HTTPResponse


### PR DESCRIPTION
This is actually the root of the issue that I was trying to fix with #56. Turns out it wasn't the django-storages version, but rather a problem with calling seek() on an HttpResponse object (generated by the requests.get call). What I did was read in the raw response data and passed that to StringIO, which seems to resolve the issue. I can now save files using the django-storages S3boto backend.

It would be great if someone could test its effectiveness with other storages.
