### PR TITLE
Add pytz to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ eventlet==0.10.0
 gunicorn==0.17.4
 netaddr==0.7.10
 requests==1.2.0
+pytz==2013b


### PR DESCRIPTION
The default behavior as of pip 1.4 is to treat any version containing substrings like a, alpha, b, beta, rc, etc. as a prerelease, which will not be installed without adding the --pre flag to the pip command line.

So, localshop depends on django-celery, which depends on pytz. As pytz is versioned with year and a letter (e.g. 2013b), the new version of pip will not install it by default. This breaks my automation (https://github.com/needle-cookbooks/chef-localshop) and is generally frustrating.

Adding a version constraint for pytz to requirements.txt fixes this right up.
