### PR TITLE
pytz dep in django-celery dep fails with pip 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Pillow==2.0.0
 celery==3.0.19
 kombu==2.5.10
 django-celery==3.0.17
+pytz>dev
 django-model-utils==1.1.0
 django-userena==1.2.0
 django-uuidfield==0.4.0


### PR DESCRIPTION
Related: agoraciudadana/agora-ciudadana#35
Related: pypa/pip#974

Seems that pip 1.4 sees pytz's wonky year-based versioning as pre-releases, so the --pre flag will be needed until django-celery fixes things. This is mostly just a heads up for the next person.
