### PR TITLE
Add settings flag to to issue a 301 rediect instead of returning the file content.

### DIFF
--- a/localshop/apps/packages/views.py
+++ b/localshop/apps/packages/views.py
@@ -177,6 +177,9 @@ def download_file(request, name, pk, filename):
         else:
             release_file = models.ReleaseFile.objects.get(pk=pk)
 
+    if settings.LOCALSHOP_ISSUE_REDIRECT:
+        return redirect("/" + release_file.distribution.url, permanent=True)
+
     # TODO: Use sendfile if enabled
     response = HttpResponse(
         FileWrapper(release_file.distribution.file),

--- a/localshop/settings.py
+++ b/localshop/settings.py
@@ -246,6 +246,8 @@ class Base(Settings):
 
     LOCALSHOP_ISOLATED = False
 
+    LOCALSHOP_ISSUE_REDIRECT = False
+
 
 class Localshop(FileSettings(os.path.join(DEFAULT_PATH, 'localshop.conf.py')), Base):
     pass


### PR DESCRIPTION
This removes the requirement to have gunicorn be the file server for packages.

When a file is requested it returns a 301 redirect to the file location, pip is smart enough to handle it. 

If you care to make sure these packages are secure, you will need to keep your htpasswd file in sync with localshops credentials.

```
http "https://localshop.example.com/packages/Django/download/4436/Django-1.5.4.tar.gz#md5=b2685469bb4d1fbb091316e21f4108de" -a <user>:<pass>
HTTP/1.1 301 MOVED PERMANENTLY
Connection: keep-alive
Content-Type: text/html; charset=utf-8
Date: Tue, 17 Sep 2013 18:40:48 GMT
Location: https://localshop.example.com/source/D/Django/Django-1.5.4.tar.gz
Server: nginx
Set-Cookie: sessionid=2km6ig31mjk3n06fz77hxmhp8qr1ccgs; expires=Tue, 01-Oct-2013 18:40:48 GMT; httponly; Max-Age=1209600; Path=/
Transfer-Encoding: chunked
Vary: Cookie
```

Here is example of the nginx config:
```
 location /source {
    # Have nginx host the file, not the gunicorn process.
    root /home/vbabiy/localshop/;

    auth_basic "Localshop";
    auth_basic_user_file  /etc/nginx/passwords/localshop.htpasswd;
  }
```