### PR TITLE
Add LOCALSHOP_RELEASE_OVERWRITE option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,3 +211,18 @@ This is useful for environments where the client has no Internet connection.
 If set to ``True`` Localshop will use the X-Forwarded-For header to validate
 the client IP address. Use this when Localshop is running behind a reverse
 proxy such as Nginx or Apache and you want to use IP-based permissions.
+
+``LOCALSHOP_RELEASE_OVERWRITE``
+----------------------
+
+:default: ``True``
+
+If set to ``False``, users will be preveneted from overwriting already existing
+release files. Can be used to encourage developers to bump versions rather than
+overwriting. This is PyPI's behaviour.
+
+.. note::
+   If you set ``LOCALSHOP_ISOLATED`` to ``True``, client request can be delayed
+   for a long time because the package must be downloaded from Internet before
+   it is served. You may want to set pip environment variable 
+   ``PIP_DEFAULT_TIMEOUT`` to a big value. Ex: ``300``

--- a/README.rst
+++ b/README.rst
@@ -221,8 +221,3 @@ If set to ``False``, users will be preveneted from overwriting already existing
 release files. Can be used to encourage developers to bump versions rather than
 overwriting. This is PyPI's behaviour.
 
-.. note::
-   If you set ``LOCALSHOP_ISOLATED`` to ``True``, client request can be delayed
-   for a long time because the package must be downloaded from Internet before
-   it is served. You may want to set pip environment variable 
-   ``PIP_DEFAULT_TIMEOUT`` to a big value. Ex: ``300``

--- a/localshop/apps/packages/views.py
+++ b/localshop/apps/packages/views.py
@@ -247,6 +247,9 @@ def handle_register_or_upload(post_data, files, user):
         filename = files['distribution']._name
         try:
             release_file = release.files.get(filename=filename)
+            if settings.LOCALSHOP_RELEASE_OVERWRITE is False:
+                message = 'That it already released, please bump version.'
+                return HttpResponseBadRequest(message)
         except ObjectDoesNotExist:
             release_file = models.ReleaseFile(
                 release=release, filename=filename, user=user)

--- a/localshop/settings.py
+++ b/localshop/settings.py
@@ -236,7 +236,7 @@ class Base(Settings):
 
     LOCALSHOP_ISOLATED = False
     
-    LOCALSHOP_RELEASE_OVERWRITE = False
+    LOCALSHOP_RELEASE_OVERWRITE = True
 
     # Use X-Forwarded-For header as the source for the client's IP.
     # Use where you have Nginx/Apache/etc as a reverse proxy infront of Localshop/Gunicorn.

--- a/localshop/settings.py
+++ b/localshop/settings.py
@@ -235,6 +235,8 @@ class Base(Settings):
     LOCALSHOP_HTTP_PROXY = None
 
     LOCALSHOP_ISOLATED = False
+    
+    LOCALSHOP_RELEASE_OVERWRITE = False
 
     # Use X-Forwarded-For header as the source for the client's IP.
     # Use where you have Nginx/Apache/etc as a reverse proxy infront of Localshop/Gunicorn.


### PR DESCRIPTION
This PR is intended to resolve #112 

Cheeseshop admins can now set `LOCALSHOP_RELEASE_OVERWRITE` to `False` to prevent users from overwriting already-released files with newer versions; a new version identifier must be given for new releases.