### PR TITLE
Fix upload on python >= 2.7.9 and >= 3.4.2

### DIFF
--- a/localshop/apps/packages/utils.py
+++ b/localshop/apps/packages/utils.py
@@ -34,8 +34,12 @@ def parse_distutils_request(request):
 
         if content.startswith('\n'):
             content = content[1:]
+        elif content.startswith("\r\n"):
+            content = content[2:]
 
-        if content.endswith('\n'):
+        if content.endswith("\r\n"):
+            content = content[:-2]
+        elif content.endswith('\n') or content.endswith("\r"):
             content = content[:-1]
 
         headers = parse_header(header)

--- a/tests/apps/packages/test_utils.py
+++ b/tests/apps/packages/test_utils.py
@@ -1,98 +1,63 @@
+import pytest
 from mock import Mock
 
-from django.test import TestCase
 from django.utils.datastructures import MultiValueDict
 
 from localshop.apps.packages.utils import parse_distutils_request
 
+LOCALSHOP_FIELDS = (
+    ("license", ["BSD"]),
+    ("name", ["localshop"]),
+    ("metadata_version", ["1.0"]),
+    ("author", ["Michael van Tellingen"]),
+    ("home_page", ["http://github.com/mvantellingen/localshop"]),
+    (":action", ["submit"]),
+    ("download_url", [None]),
+    ("summary", ["A private pypi server including auto-mirroring of pypi."]),
+    ("author_email", ["michaelvantellingen@gmail.com"]),
+    ("version", ["0.1"]),
+    ("platform", [None]),
+    ("classifiers", [
+        "Development Status :: 2 - Pre-Alpha",
+        "'Framework :: Django",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development",
+    ]),
+    ("description", [None]),
+)
 
-class TestParseDistutilsRequest(TestCase):
-    def test_register_post(self):
-        data = (
-            '\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="license"\n\n'
-            'BSD\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="name"\n\nlocalshop\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="metadata_version"\n\n'
-            '1.0\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="author"\n\n'
-            'Michael van Tellingen\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="home_page"\n\n'
-            'http://github.com/mvantellingen/localshop\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name=":action"\n\n'
-            'submit\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="download_url"\n\n'
-            'UNKNOWN\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="summary"\n\n'
-            'A private pypi server including auto-mirroring of pypi.\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="author_email"\n\n'
-            'michaelvantellingen@gmail.com\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="version"\n\n'
-            '0.1\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="platform"\n\n'
-            'UNKNOWN\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="classifiers"\n\n'
-            'Development Status :: 2 - Pre-Alpha\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="classifiers"\n\n'
-            'Framework :: Django\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="classifiers"\n\n'
-            'Intended Audience :: Developers\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="classifiers"\n\n'
-            'Intended Audience :: System Administrators\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="classifiers"\n\n'
-            'Operating System :: OS Independent\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="classifiers"\n\n'
-            'Topic :: Software Development\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\n'
-            'Content-Disposition: form-data; name="description"\n\n'
-            'UNKNOWN\n'
-            '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\n'
-        )
-        request = Mock()
-        request.body = data
-        request.FILES = MultiValueDict()
-        parse_distutils_request(request)
 
-        expected_post = MultiValueDict({
-            'name': ['localshop'],
-            'license': ['BSD'],
-            'author': ['Michael van Tellingen'],
-            'home_page': ['http://github.com/mvantellingen/localshop'],
-            ':action': ['submit'],
-            'download_url': [None],
-            'summary': [
-                'A private pypi server including auto-mirroring of pypi.'],
-            'author_email': ['michaelvantellingen@gmail.com'],
-            'metadata_version': ['1.0'],
-            'version': ['0.1'],
-            'platform': [None],
-            'classifiers': [
-                'Development Status :: 2 - Pre-Alpha',
-                'Framework :: Django',
-                'Intended Audience :: Developers',
-                'Intended Audience :: System Administrators',
-                'Operating System :: OS Independent',
-                'Topic :: Software Development'
-            ],
-            'description': [None]
-        })
-        expected_files = MultiValueDict()
+def get_raw_form_data(fields, crlf=False):
+    if crlf:
+        # Python >=2.7.9 and >=3.4.2
+        # See http://bugs.python.org/issue10510
+        nl = "\r\n"
+    else:
+        nl = "\n"
+    boundary = nl + "----------------GHSKFJDLGDS7543FJKLFHRE75642756743254" + nl
+    data = boundary
+    for key, values in fields:
+        for value in values:
+            if value is None:
+                value = "UNKNOWN"
+            data += nl + 'Content-Disposition: form-data; name="%s"' % (key,)
+            data += 2 * nl
+            data += value
+            data += boundary
+    return data
 
-        self.assertEqual(request.POST, expected_post)
-        self.assertEqual(request.FILES, expected_files)
+
+@pytest.mark.parametrize("crlf", [True, False])
+def test_register_post(crlf):
+    request = Mock()
+    request.body = get_raw_form_data(LOCALSHOP_FIELDS, crlf)
+    request.FILES = MultiValueDict()
+    parse_distutils_request(request)
+
+    expected_post = MultiValueDict(LOCALSHOP_FIELDS)
+    expected_files = MultiValueDict()
+
+    assert request.POST == expected_post
+    assert request.FILES == expected_files


### PR DESCRIPTION
http://bugs.python.org/issue10510 fix HTML compliance of distutils
upload requests.

See the changeset on python 2.7: https://hg.python.org/cpython/rev/9ad78b4b169c

This will be released in 2.7.9 and is already relased in 3.4.2.

Localshop needs to handle both methods.


Also, I've done some refactoring on tests (more pytest style)