### PR TITLE
Add a /local/ view with all local and mirrored files

### DIFF
--- a/localshop/apps/packages/views.py
+++ b/localshop/apps/packages/views.py
@@ -120,6 +120,27 @@ class SimpleDetail(DetailView):
 simple_detail = SimpleDetail.as_view()
 
 
+class LocalList(ListView):
+    """Index with all mirrored or local files
+
+    This page can be used by pip as url for --find-links option and when used
+    with --no-index we ensure that no request can be done to pypi.python.org
+    """
+
+    queryset = models.ReleaseFile.objects.exclude(
+        distribution="",
+    ).order_by("release__package__name")
+    context_object_name = "files"
+    http_method_names = ["get"]
+    template_name = "packages/local_list.html"
+
+    @method_decorator(credentials_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super(LocalList, self).dispatch(request, *args, **kwargs)
+
+local_list = LocalList.as_view()
+
+
 class Index(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     model = models.Package
     context_object_name = 'packages'

--- a/localshop/templates/packages/local_list.html
+++ b/localshop/templates/packages/local_list.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+      <meta charset="utf-8" />
+      <title>Local files</title>
+      <style>
+        a { display: block; }
+      </style>
+  </head>
+  <body>
+    <h1>Local files</h1>
+{% for file in files %}
+    <a href="{{ file.get_absolute_url }}" rel="package">{{ file.filename }}</a>
+{% endfor %}
+  </body>
+</html>

--- a/localshop/urls.py
+++ b/localshop/urls.py
@@ -27,6 +27,8 @@ urlpatterns = patterns('',
     # POST requests to /simple/ and /simple both work
     url(r'^simple$', 'localshop.apps.packages.views.simple_index'),
 
+    url(r'^local/', 'localshop.apps.packages.views.local_list'),
+
     url(r'^permissions/',
         include('localshop.apps.permissions.urls', namespace='permissions')),
 


### PR DESCRIPTION
This view can be used with pip as find-links options.

With pip install --no-index -f https://localshop/local/ we can ensure
that localshop works even when pypi.python.org is unreacheable (from
localshop server if LOCALSHOP_ISOLATED is enabled or from pip client).