### PR TITLE
Support reverse proxies for IP-based permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,3 +196,12 @@ This is useful for environments where the client has no Internet connection.
    for a long time because the package must be downloaded from Internet before
    it is served. You may want to set pip environment variable 
    ``PIP_DEFAULT_TIMEOUT`` to a big value. Ex: ``300``
+
+``LOCALSHOP_USE_PROXIED_IP``
+----------------------------
+
+:default: ``False``
+
+If set to ``True`` Localshop will use the X-Forwarded-For header to validate
+the client IP address. Use this when Localshop is running behind a reverse
+proxy such as Nginx or Apache and you want to use IP-based permissions.

--- a/localshop/settings.py
+++ b/localshop/settings.py
@@ -237,6 +237,10 @@ class Base(Settings):
 
     LOCALSHOP_ISOLATED = False
 
+    # Use X-Forwarded-For header as the source for the client's IP.
+    # Use where you have Nginx/Apache/etc as a reverse proxy infront of Localshop/Gunicorn.
+    LOCALSHOP_USE_PROXIED_IP = False
+
 
 class TestConfig(Base):
     SECRET_KEY = "TEST-KEY"

--- a/tests/apps/permissions/test_utils.py
+++ b/tests/apps/permissions/test_utils.py
@@ -1,0 +1,64 @@
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+from localshop.apps.permissions.utils import credentials_required
+from localshop.apps.permissions import models
+
+
+@credentials_required
+def myview(request):
+    return HttpResponse('ok')
+
+
+class ProxiedIPText(TestCase):
+    def setUp(self):
+        models.CIDR.objects.create(cidr='192.168.1.1', require_credentials=False)
+        self.factory = RequestFactory()
+
+    def test_disabled(self):
+        # never look at X-Forwarded-For if the setting is disabled (default)
+        req = self.factory.get('/', REMOTE_ADDR='192.168.1.1', HTTP_X_FORWARDED_FOR='10.1.1.1')
+        resp = myview(req)
+        self.assertEqual(resp.status_code, 200)
+
+        req = self.factory.get('/', REMOTE_ADDR='127.0.0.1', HTTP_X_FORWARDED_FOR='192.168.1.1')
+        resp = myview(req)
+        self.assertEqual(resp.status_code, 403)
+
+        req = self.factory.get('/', REMOTE_ADDR='10.1.1.1', HTTP_X_FORWARDED_FOR='192.168.1.1')
+        resp = myview(req)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_proxied(self):
+        with override_settings(LOCALSHOP_USE_PROXIED_IP=True):
+            req = self.factory.get('/', REMOTE_ADDR='127.0.0.1', HTTP_X_FORWARDED_FOR='192.168.1.1')
+            resp = myview(req)
+            self.assertEqual(resp.status_code, 200)
+
+            req = self.factory.get('/', REMOTE_ADDR='192.168.1.1', HTTP_X_FORWARDED_FOR='10.1.1.1')
+            resp = myview(req)
+            self.assertEqual(resp.status_code, 403)
+
+    def test_proxied_last(self):
+        # only the last hop counts (first in the list)
+        with override_settings(LOCALSHOP_USE_PROXIED_IP=True):
+            req = self.factory.get('/', REMOTE_ADDR='127.0.0.1', HTTP_X_FORWARDED_FOR='192.168.1.1, 10.1.1.1')
+            resp = myview(req)
+            self.assertEqual(resp.status_code, 200)
+
+            req = self.factory.get('/', REMOTE_ADDR='127.0.0.1', HTTP_X_FORWARDED_FOR='10.1.1.1, 192.168.1.1')
+            resp = myview(req)
+            self.assertEqual(resp.status_code, 403)
+
+    def test_proxied_mising(self):
+        with override_settings(LOCALSHOP_USE_PROXIED_IP=True):
+            req = self.factory.get('/', REMOTE_ADDR='127.0.0.1')
+            resp = myview(req)
+            self.assertEqual(resp.status_code, 403)
+
+            # only uses the header, never falls back to REMOTE_ADDR
+            req = self.factory.get('/', REMOTE_ADDR='192.168.1.1')
+            resp = myview(req)
+            self.assertEqual(resp.status_code, 403)


### PR DESCRIPTION
Fix for #111, allows running LocalShop behind a reverse proxy such as Nginx or Apache and having IP-based permission checks work.

Adds a new setting `LOCALSHOP_USE_PROXIED_IP`, which when True enables using the standard `X-Forwarded-For` header rather than `request.REMOTE_ADDR` for IP-based permission checks. Default is False for obvious security reasons.