### PR TITLE
Fixed a bug with upload from later Python version (>=2.7.4)

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,5 @@
 mock==1.0.1
 coverage==3.6
 coveralls
-django-nose==1.2
+pytest-django
 factory_boy==2.3.1

--- a/tests/apps/packages/test_views.py
+++ b/tests/apps/packages/test_views.py
@@ -1,99 +1,211 @@
-from django.contrib.auth.models import User
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
-from django.utils.datastructures import MultiValueDict
+from base64 import standard_b64encode
 
-from localshop.apps.packages import models
-from localshop.apps.packages import views
+import pytest
+import requests
+
+from localshop.apps.packages.models import Package
+from localshop.apps.permissions.models import CIDR
 
 
-class TestDistutilsViews(TestCase):
+@pytest.mark.parametrize('separator', ['\n', '\r\n'])
+def test_package_upload(live_server, admin_user, separator):
+    CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
 
-    def test_register_new(self):
-        post = MultiValueDict({
-            'name': ['localshop'],
-            'license': ['BSD'],
-            'author': ['Michael van Tellingen'],
-            'home_page': ['http://github.com/mvantellingen/localshop'],
-            ':action': ['submit'],
-            'download_url': [None],
-            'summary': [
-                'A private pypi server including auto-mirroring of pypi.'],
-            'author_email': ['michaelvantellingen@gmail.com'],
-            'metadata_version': ['1.0'],
-            'version': ['0.1'],
-            'platform': [None],
-            'classifiers': [
-                'Development Status :: 2 - Pre-Alpha',
-                'Framework :: Django',
-                'Intended Audience :: Developers',
-                'Intended Audience :: System Administrators',
-                'Operating System :: OS Independent',
-                'Topic :: Software Development'
-            ],
-            'description': [None]
-        })
-        files = MultiValueDict()
+    post_data = separator.join([
+        '',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="comment"',
+        '',
+        '',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="metadata_version"',
+        '',
+        '1.0',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="filetype"',
+        '',
+        'sdist',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="protcol_version"',
+        '',
+        '1',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="author"',
+        '',
+        'Michael van Tellingen',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="home_page"',
+        '',
+        'http://github.com/mvantellingen/localshop',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="download_url"',
+        '',
+        'UNKNOWN',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="content";filename="tmpf3bcEV"',
+        '',
+        'binary-test-data-here',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="platform"',
+        '',
+        'UNKNOWN',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="version"',
+        '',
+        '0.1',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="description"',
+        '',
+        'UNKNOWN',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="md5_digest"',
+        '',
+        '06ffe94789d7bd9efba1109f40e935cf',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name=":action"',
+        '',
+        'file_upload',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="name"',
+        '',
+        'localshop',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="license"',
+        '',
+        'BSD',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="pyversion"',
+        '',
+        'source',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="summary"',
+        '',
+        'A private pypi server including auto-mirroring of pypi.',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="author_email"',
+        '',
+        'michaelvantellingen@gmail.com',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--',
+        ''])
 
-        user = User.objects.create_user('john', 'john@example.org', 'secret')
-        response = views.handle_register_or_upload(post, files, user)
-        self.assertEqual(response.status_code, 200, response.content)
+    headers = {
+        'Content-type': 'multipart/form-data; boundary=--------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Authorization': 'Basic ' + standard_b64encode('admin:password')
+    }
 
-        package = models.Package.objects.get(name='localshop')
-        self.assertEqual(package.releases.count(), 1)
+    response = requests.post(live_server + '/simple/', post_data, headers=headers)
 
-    def test_upload_new(self):
-        post = MultiValueDict({
-            'name': ['localshop'],
-            'license': ['BSD'],
-            'author': ['Michael van Tellingen'],
-            'home_page': ['http://github.com/mvantellingen/localshop'],
-            ':action': ['submit'],
-            'download_url': [None],
-            'summary': [
-                'A private pypi server including auto-mirroring of pypi.'],
-            'author_email': ['michaelvantellingen@gmail.com'],
-            'metadata_version': ['1.0'],
-            'version': ['0.1'],
-            'platform': [None],
-            'classifiers': [
-                'Development Status :: 2 - Pre-Alpha',
-                'Framework :: Django',
-                'Intended Audience :: Developers',
-                'Intended Audience :: System Administrators',
-                'Operating System :: OS Independent',
-                'Topic :: Software Development'
-            ],
-            'description': [None],
+    assert response.status_code == 200
 
-            # Extra fields for upload
-            'pyversion': [''],
-            'filetype': ['sdist'],
-            'md5_digest': ['dc8f0311bb830ee96b8627f8335f2cb1'],
-        })
-        files = MultiValueDict({
-            'distribution': [
-                SimpleUploadedFile(
-                    'localshop-0.1.tar.gz', 'binary-test-data-here')
-            ]
-        })
+    package = Package.objects.filter(name='localshop').first()
 
-        user = User.objects.create_user('john', 'john@example.org', 'secret')
-        response = views.handle_register_or_upload(post, files, user)
-        self.assertEqual(response.status_code, 200, response.content)
+    assert package is not None
+    assert package.is_local is True
+    assert package.releases.count() == 1
 
-        package = models.Package.objects.get(name='localshop')
-        self.assertEqual(package.releases.count(), 1)
-        self.assertTrue(package.is_local)
+    release = package.releases.first()
 
-        release = package.releases.all()[0]
-        self.assertEqual(release.files.count(), 1)
+    assert release.author == 'Michael van Tellingen'
+    assert release.author_email == 'michaelvantellingen@gmail.com'
+    assert release.description == ''
+    assert release.download_url == ''
+    assert release.home_page == 'http://github.com/mvantellingen/localshop'
+    assert release.license == 'BSD'
+    assert release.metadata_version == '1.0'
+    assert release.summary == 'A private pypi server including auto-mirroring of pypi.'
+    assert release.user == admin_user
+    assert release.version == '0.1'
+    assert release.files.count() == 1
 
-        release_file = release.files.all()[0]
-        self.assertEqual(release_file.python_version, 'source')
-        self.assertEqual(release_file.filetype, 'sdist')
-        self.assertEqual(release_file.md5_digest,
-            'dc8f0311bb830ee96b8627f8335f2cb1')
-        self.assertEqual(release_file.filename, 'localshop-0.1.tar.gz')
-        self.assertEqual(release_file.distribution.read(),
-            'binary-test-data-here')
+    release_file = release.files.first()
+
+    assert release_file is not None
+    assert release_file.python_version == 'source'
+    assert release_file.filetype == 'sdist'
+    assert release_file.md5_digest == '06ffe94789d7bd9efba1109f40e935cf'
+    assert release_file.distribution.read() == 'binary-test-data-here'
+
+
+def test_package_register(live_server, admin_user):
+    CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
+
+    post_data = '\n'.join([
+        '',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="license"',
+        '',
+        'BSD',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="name"',
+        '',
+        'localshop',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="metadata_version"',
+        '',
+        '1.0',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="author"',
+        '',
+        'Michael van Tellingen',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="home_page"',
+        '',
+        'http://github.com/mvantellingen/localshop',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name=":action"',
+        '',
+        'submit',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="download_url"',
+        '',
+        'UNKNOWN',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="summary"',
+        '',
+        'A private pypi server including auto-mirroring of pypi.',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="author_email"',
+        '',
+        'michaelvantellingen@gmail.com',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="version"',
+        '',
+        '0.1',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="platform"',
+        '',
+        'UNKNOWN',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Content-Disposition: form-data; name="description"',
+        '',
+        'UNKNOWN',
+        '----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--',
+        ''])
+
+    headers = {
+        'Content-type': 'multipart/form-data; boundary=--------------GHSKFJDLGDS7543FJKLFHRE75642756743254',
+        'Authorization': 'Basic ' + standard_b64encode('admin:password')
+    }
+
+    response = requests.post(live_server + '/simple/', post_data, headers=headers)
+
+    assert response.status_code == 200
+
+    package = Package.objects.filter(name='localshop').first()
+
+    assert package is not None
+    assert package.is_local is True
+    assert package.releases.count() == 1
+
+    release = package.releases.first()
+
+    assert release.author == 'Michael van Tellingen'
+    assert release.author_email == 'michaelvantellingen@gmail.com'
+    assert release.description == ''
+    assert release.download_url == ''
+    assert release.home_page == 'http://github.com/mvantellingen/localshop'
+    assert release.license == 'BSD'
+    assert release.metadata_version == '1.0'
+    assert release.summary == 'A private pypi server including auto-mirroring of pypi.'
+    assert release.user == admin_user
+    assert release.version == '0.1'


### PR DESCRIPTION
Now the `parse_distutils_request` function supports both `\n` and `\r\n` as separators.

I also updated the `test_views` module in order to cover both scenarios. 

Since the project tox.ini file is using py.test I took the liberty of converting the `test_views` module to a py.test style. I also updated the tests to use real post data that I generated from the distutils itself. The tests are covering both distutils before 2.7.4 and after.

Fixes #117 