### PR TITLE
allow spaces in package names.

### DIFF
--- a/localshop/apps/packages/urls.py
+++ b/localshop/apps/packages/urls.py
@@ -6,10 +6,10 @@ from localshop.apps.packages import views
 urlpatterns = patterns('',
     url(r'^$', views.Index.as_view(), name='index'),
 
-    url(r'^(?P<name>[-\._\w]+)/$', views.Detail.as_view(), name='detail'),
+    url(r'^(?P<name>[-\._\w\ ]+)/$', views.Detail.as_view(), name='detail'),
 
-    url(r'^(?P<name>[-\._\w]+)/refresh',
+    url(r'^(?P<name>[-\._\w\ ]+)/refresh',
         views.refresh, name='refresh'),
-    url(r'^(?P<name>[-\._\w]+)/download/(?P<pk>\d+)/(?P<filename>.*)$',
+    url(r'^(?P<name>[-\._\w\ ]+)/download/(?P<pk>\d+)/(?P<filename>.*)$',
         views.download_file, name='download'),
 )

--- a/localshop/apps/packages/urls_simple.py
+++ b/localshop/apps/packages/urls_simple.py
@@ -2,6 +2,6 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('localshop.apps.packages.views',
     url(r'^$', 'simple_index', name='simple_index'),
-    url(r'^(?P<slug>[-\._\w]+)/?(?P<version>.*?)/?$', 'simple_detail',
+    url(r'^(?P<slug>[-\._\w\ ]+)/?(?P<version>.*?)/?$', 'simple_detail',
         name='simple_detail')
 )


### PR DESCRIPTION
We have some legacy packages that contain spaces in the name.
Without this change, localshop will 500 after a user logs in.