### PR TITLE
adding refresh command

### DIFF
--- a/localshop/management/commands/refresh.py
+++ b/localshop/management/commands/refresh.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+
+from ...apps.packages.models import Package
+from ...apps.packages.pypi import get_package_data
+
+
+class Command(BaseCommand):
+    help = "refreshes (downloads new versions) all packages from pypi"
+
+    def handle(self, *args, **kwargs):
+        for package in Package.objects.filter(is_local=False):
+            get_package_data(package.name, package)


### PR DESCRIPTION
I often find that my localshop is missing the latest versions from pypi. 

Ultimately i have to go to the site and press the reset button.

This code is abstracted from the refresh view and is meant to refresh all packages (from pypi).