### PR TITLE
Add /pypi as an XMLRPC endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ localshop.db
 *.swp
 .coverage
 docker.conf.py
+.cache

--- a/localshop/urls.py
+++ b/localshop/urls.py
@@ -16,6 +16,7 @@ urlpatterns = patterns('',
 
     # Default path for xmlrpc calls
     url(r'^RPC2$', handle_request),
+    url(r'^pypi$', handle_request),
 
     url(r'^packages/',
         include('localshop.apps.packages.urls', namespace='packages')),

--- a/tests/apps/packages/test_xmlrpc.py
+++ b/tests/apps/packages/test_xmlrpc.py
@@ -5,13 +5,18 @@ from localshop.apps.permissions.models import CIDR
 from tests.apps.packages.factories import ReleaseFactory
 
 
+@pytest.fixture(params=['/RPC2', '/pypi'])
+def rpc_endpoint(request):
+    return request.param
+
+
 @pytest.mark.django_db
-def test_search_package_name(client, admin_user, live_server):
+def test_search_package_name(client, admin_user, live_server, rpc_endpoint):
     CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
     ReleaseFactory(package__name='my-package',
                    summary='Test summary')
 
-    client = xmlrpclib.ServerProxy(live_server + '/RPC2')
+    client = xmlrpclib.ServerProxy(live_server + rpc_endpoint)
     response = client.search({'name': 'my-package'})
 
     assert response == [{
@@ -22,12 +27,12 @@ def test_search_package_name(client, admin_user, live_server):
 
 
 @pytest.mark.django_db
-def test_search_package_summary(client, admin_user, live_server):
+def test_search_package_summary(client, admin_user, live_server, rpc_endpoint):
     CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
     ReleaseFactory(package__name='my-package',
                    summary='Test summary')
 
-    client = xmlrpclib.ServerProxy(live_server + '/RPC2')
+    client = xmlrpclib.ServerProxy(live_server + rpc_endpoint)
     response = client.search({'summary': ['Test summary']})
 
     assert response == [{
@@ -38,7 +43,7 @@ def test_search_package_summary(client, admin_user, live_server):
 
 
 @pytest.mark.django_db
-def test_search_operator_and(client, admin_user, live_server):
+def test_search_operator_and(client, admin_user, live_server, rpc_endpoint):
     CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
     ReleaseFactory(package__name='my-package-1',
                    summary='Test summary')
@@ -49,7 +54,7 @@ def test_search_operator_and(client, admin_user, live_server):
     ReleaseFactory(package__name='my-package-2',
                    summary='arcoiro')
 
-    client = xmlrpclib.ServerProxy(live_server + '/RPC2')
+    client = xmlrpclib.ServerProxy(live_server + rpc_endpoint)
     response = client.search({'name': ['my-package'],
                               'summary': ['Test summary']}, 'and')
 
@@ -61,7 +66,7 @@ def test_search_operator_and(client, admin_user, live_server):
 
 
 @pytest.mark.django_db
-def test_search_operator_or(client, admin_user, live_server):
+def test_search_operator_or(client, admin_user, live_server, rpc_endpoint):
     CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
     ReleaseFactory(package__name='my-package-1',
                    summary='Test summary')
@@ -72,7 +77,7 @@ def test_search_operator_or(client, admin_user, live_server):
     ReleaseFactory(package__name='my-package-2',
                    summary='arcoiro')
 
-    client = xmlrpclib.ServerProxy(live_server + '/RPC2')
+    client = xmlrpclib.ServerProxy(live_server + rpc_endpoint)
     response = client.search({'name': ['my-package'],
                               'summary': ['Test summary']}, 'or')
 
@@ -97,12 +102,12 @@ def test_search_operator_or(client, admin_user, live_server):
 
 
 @pytest.mark.django_db
-def test_search_invalid_fields_are_ignores(client, admin_user, live_server):
+def test_search_invalid_fields_are_ignores(client, admin_user, live_server, rpc_endpoint):
     CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
     ReleaseFactory(package__name='my-package',
                    summary='Test summary')
 
-    client = xmlrpclib.ServerProxy(live_server + '/RPC2')
+    client = xmlrpclib.ServerProxy(live_server + rpc_endpoint)
     response = client.search({'name': ['my-package'], 'invalid': ['Ops']})
 
     assert response == [{

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
 setenv =
     DJANGO_SETTINGS_MODULE = localshop.settings
     DJANGO_CONFIGURATION=TestConfig
-commands = py.test tests --cov localshop --cov-report term-missing
+commands = py.test {posargs:tests --cov localshop --cov-report term-missing}
 
 
 [testenv:docs]


### PR DESCRIPTION
- Add `/pypi` as an XMLRPC endpoint, to work more closely with the Official PyPI
- Change default tox command to use `{posargs}`
- Ignore `pytest-xdist` folder (at `.gitignore`)