### PR TITLE
Validate package name

### DIFF
--- a/localshop/apps/packages/forms.py
+++ b/localshop/apps/packages/forms.py
@@ -11,6 +11,26 @@ class PypiReleaseDataForm(forms.ModelForm):
             'home_page', 'license', 'summary', 'version',
         ]
 
+class PackageForm(forms.ModelForm):
+    class Meta:
+        model = models.Package
+        fields = [
+            'name',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        self._user = kwargs.pop("user")
+        super(PackageForm, self).__init__(*args, **kwargs)
+        self.base_fields['name'].error_messages.update({
+            'invalid': 'Enter a valid name consisting of letters, numbers, underscores or hyphens '
+        })
+
+    def save(self):
+        obj = super(PackageForm, self).save()
+        obj.is_local = True
+        obj.owners.add(self._user)
+        obj.save()
+        return obj
 
 class ReleaseForm(forms.ModelForm):
     class Meta:

--- a/localshop/apps/packages/views.py
+++ b/localshop/apps/packages/views.py
@@ -244,9 +244,10 @@ def handle_register_or_upload(post_data, files, user):
         return HttpResponseBadRequest('ERRORS %s' % form.errors)
 
     if not package:
-        package = models.Package.objects.create(name=name, is_local=True)
-        package.owners.add(user)
-        package.save()
+        pkg_form = forms.PackageForm(post_data, user=user)
+        if not pkg_form.is_valid():
+            return HttpResponseBadRequest('ERRORS %s' % pkg_form.errors.as_text())
+        package = pkg_form.save()
 
     release = form.save(commit=False)
     release.package = package

--- a/tests/apps/packages/views/test_simple_index.py
+++ b/tests/apps/packages/views/test_simple_index.py
@@ -312,6 +312,27 @@ def test_upload_should_not_overwrite_pypi_package(live_server, admin_user):
     assert response.content == 'localshop is a pypi package!'
 
 
+def test_package_name_with_whitespace(live_server, admin_user):
+    CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
+
+    headers = {
+        'Authorization': 'Basic ' + standard_b64encode('admin:password')
+    }
+
+    data = {
+        ':action': 'file_upload',
+        'version': '1.0',
+        'metadata_version': '1.0',
+        'filetype': 'sdist',
+        'md5_digest': '06ffe94789d7bd9efba1109f40e935cf',
+    }
+    data["name"] = "invalid name"
+    response = requests.post(live_server + '/simple/', data=data, files={'content': 'Hi'}, headers=headers)
+
+    assert response.status_code == 400
+    assert "Enter a valid name consisting of letters, numbers, underscores or hyphens" in response.content
+
+
 def test_package_name_with_hyphen_instead_underscore(live_server, admin_user):
     CIDR.objects.create(cidr='0.0.0.0/0', require_credentials=False)
 


### PR DESCRIPTION
Without this patch it is possible to submit packages that are not named in accordance to the slugfield on
the Package-Model. This then breaks the Index-View because there is no reverse for a Package name that does not comply with the slugfield e.g "My Package"  cannot be reversed with `url(r'^(?P<name>[-\._\w]+)/$', views.Detail.as_view(), name='detail')`