### PR TITLE
Use the storage's exists method to test if the file is available

### DIFF
--- a/localshop/apps/packages/models.py
+++ b/localshop/apps/packages/models.py
@@ -189,7 +189,7 @@ class ReleaseFile(models.Model):
 
     @property
     def file_is_available(self):
-        return self.distribution and os.path.isfile(self.distribution.path)
+        return self.distribution and self.distribution.storage.exists(self.distribution.name)
 
     def download(self):
         """Start a celery task to download the release file from pypi.


### PR DESCRIPTION
Fixes #152

This should fix the S3 storage and other remote file storages.

I'm also working on a patch for Django to support `exists` on the FileField in the same way `path` and other fields are supported.