### PR TITLE
docs: Fix installation steps for docker

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -48,7 +48,6 @@ Install docker and docker-compose and then run:
 
 .. code-block:: bash
 
-    cp docker.conf.py{.example,}
     docker-compose build
     docker-compose run localshop syncdb
     docker-compose run localshop createsuperuser


### PR DESCRIPTION
`docker.conf.py.example` has been renamed to `docker.conf.py` (8223777105d2cdc6748abfece91116fa652fbfd5). This PR fixes the documentation