### PR TITLE
add closing tags to simple package detail template

### DIFF
--- a/localshop/templates/packages/simple_package_detail.html
+++ b/localshop/templates/packages/simple_package_detail.html
@@ -24,3 +24,5 @@
         {% endif %}
     {% endfor %}
 {% endfor %}
+    </body>
+</html>


### PR DESCRIPTION
this adds closing body and html tags to the simple package detail template so tools that use strict xml parsing don't bomb out.