### PR TITLE
Increase py_version size due to packages on pypi

### DIFF
--- a/localshop/apps/packages/migrations/0007_auto_20150909_2245.py
+++ b/localshop/apps/packages/migrations/0007_auto_20150909_2245.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('packages', '0006_repository_upstream_pypi_url'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='releasefile',
+            name='python_version',
+            field=models.CharField(max_length=50),
+            preserve_default=True,
+        ),
+    ]

--- a/localshop/apps/packages/models.py
+++ b/localshop/apps/packages/models.py
@@ -200,7 +200,7 @@ class ReleaseFile(models.Model):
 
     md5_digest = models.CharField(max_length=512)
 
-    python_version = models.CharField(max_length=25)
+    python_version = models.CharField(max_length=50)
 
     url = models.CharField(max_length=1024, blank=True)
 


### PR DESCRIPTION
example: https://pypi.python.org/pypi/pyenchant has py_version of 37
characters