### PR TITLE
Fix nightly update of packages

### DIFF
--- a/localshop/apps/packages/tasks.py
+++ b/localshop/apps/packages/tasks.py
@@ -133,5 +133,5 @@ def update_packages():
     logging.info('Updated packages')
     for package in models.Package.objects.filter(is_local=False):
         logging.info('Updating package %s', package.name)
-        enqueue(fetch_package, package.name)
+        enqueue(fetch_package, package.repository_id, package.name)
     logging.info('Complete')


### PR DESCRIPTION
Don't know if any development / maintenance is planned for localshop (seems a bit quiet around the project ...). But there was an issue in the develop branch with the nightly update of packages from pypi (missing repo id arg for the fetch_package task).