### PR TITLE
Fix the PyPi dots replacement issue

### DIFF
--- a/localshop/apps/packages/pypi.py
+++ b/localshop/apps/packages/pypi.py
@@ -47,16 +47,16 @@ def get_search_names(name):
     pyramid-debugtoolbar.
 
     """
-    parts = re.split('[-_]', name)
+    parts = re.split('[-_.]', name)
     if len(parts) == 1:
         return parts
 
     result = set()
     for i in range(len(parts) - 1, 0, -1):
-        for s1 in '-_':
+        for s1 in '-_.':
             prefix = s1.join(parts[:i])
-            for s2 in '-_':
+            for s2 in '-_.':
                 suffix = s2.join(parts[i:])
-                for s3 in '-_':
+                for s3 in '-_.':
                     result.add(s3.join([prefix, suffix]))
     return list(result)


### PR DESCRIPTION
Backgound:  (https://github.com/pypa/pip/issues/3677)
Since PIP version 8.1.2 (May 2016) the url to look up for the package is constructed replacing all dot's in the name of the package to dashes. It works fine with pypi.python.org because apparently it's smart enough to understand that replacement. With other servers, though, like localshop, things break because they see packages with names like zope.interface and zope-interface as two different packages. And even though you have zope.interface on your server, it doesn't help you to install zope-interface as it's being requested by pip.

This pull request is to solve this issue by adding an addition search condition dot. 
For example: 
pip install -i http://localhost:8000/simple/ zope[-_.]interface will search three different kinds of packages in the localshop. 
zope-interface 
zope_interface 
zope.interface

Reference: PEP 503 Normalized Names: 
https://www.python.org/dev/peps/pep-0503/#normalized-names