### PR TITLE
Improve compatibility with Django 1.11 by removing future template tag

### DIFF
--- a/src/localshop/templates/registration/password_change_done.html
+++ b/src/localshop/templates/registration/password_change_done.html
@@ -1,7 +1,6 @@
 {% extends 'layout.main.html' %}
 
 {% load i18n %}
-{% load url from future %}
 
 
 {% block title %}{% trans "Change password" %}{% endblock %}

--- a/src/localshop/templates/registration/password_reset_complete.html
+++ b/src/localshop/templates/registration/password_reset_complete.html
@@ -1,7 +1,6 @@
 {% extends 'layout.base.html' %}
 
 {% load i18n %}
-{% load url from future %}
 
 
 {% block title %}{{ title }}{% endblock %}

--- a/src/localshop/templates/registration/password_reset_confirm.html
+++ b/src/localshop/templates/registration/password_reset_confirm.html
@@ -1,7 +1,6 @@
 {% extends 'layout.base.html' %}
 
 {% load i18n %}
-{% load url from future %}
 
 
 {% block content %}


### PR DESCRIPTION
This pull request improves compatibility with Django 1.11 by removing the future template tags. The future template tags are deprecated and have been removed since Django 1.9.