### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,7 +2,7 @@ Contributing
 ############
 
 Want to contribute with Localshop? Great! We really appreciate your help. But
-before digging into your new fluffy-next-millionaine-feature code keep in mind
+before digging into your new fluffy-next-millionaire-feature code keep in mind
 that you **MUST** follow this guide to get your pull requests approved.
 
 
@@ -131,7 +131,7 @@ Commit messages
     - |book| ``:book:`` when writing docs
     - |green_heart| ``:green_heart:`` when fixing the CI build
     - |white_check_mark| ``:white_check_mark:`` when adding tests
-    - |x| ``:x:`` when commiting code with failed tests
+    - |x| ``:x:`` when committing code with failed tests
     - |arrow_up| ``:arrow_up:`` when upgrading dependencies
     - |arrow_down| ``:arrow_down:`` when downgrading dependencies
 

--- a/docs/how_it_works.rst
+++ b/docs/how_it_works.rst
@@ -58,7 +58,7 @@ uploads and downloads you can easily create one of the random credentials
 localshop can create for you.
 
 Go to the Credentials section and click on create. Use the access key
-as the username and the secret key as the password when uloading packages.
+as the username and the secret key as the password when uploading packages.
 A ``~/.pypirc`` could look like this:
 
 .. code-block:: ini

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -57,7 +57,7 @@ proxy such as Nginx or Apache and you want to use IP-based permissions.
 
 :default: ``True``
 
-If set to ``False``, users will be preveneted from overwriting already existing
+If set to ``False``, users will be prevented from overwriting already existing
 release files. Can be used to encourage developers to bump versions rather than
 overwriting. This is PyPI's behaviour.
 

--- a/src/localshop/apps/accounts/views.py
+++ b/src/localshop/apps/accounts/views.py
@@ -188,7 +188,7 @@ def login(request, template_name='registration/login.html',
           current_app=None, extra_context=None):
     """Displays the login form and handles the login action.
 
-    Copy from Django source code, added abilithy to set remember_me
+    Copy from Django source code, added ability to set remember_me
 
     """
     redirect_to = request.POST.get(redirect_field_name,


### PR DESCRIPTION
There are small typos in:
- docs/contributing.rst
- docs/how_it_works.rst
- docs/settings.rst
- src/localshop/apps/accounts/views.py

Fixes:
- Should read `uploading` rather than `uloading`.
- Should read `prevented` rather than `preveneted`.
- Should read `millionaire` rather than `millionaine`.
- Should read `committing` rather than `commiting`.
- Should read `ability` rather than `abilithy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md